### PR TITLE
Fix to parse escaped connect argument

### DIFF
--- a/pkg/game/argument/connect.go
+++ b/pkg/game/argument/connect.go
@@ -58,12 +58,28 @@ func (argument *Connect) ValidateLazy() (err error) {
 	return
 }
 
-func (argument *Connect) ParseWithIP(ip string) (string, error) {
+func (argument *Connect) ParseWithIP(ip string) (args []string, err error) {
 	arg, err := argument.Parse(Seperator{})
 	if err != nil {
-		return "", err
+		return args, err
 	}
-	return strings.Replace(arg, "?", ip, 1), nil
+
+	arg, prefixFound := strings.CutPrefix(arg, "\"")
+	arg, suffixFound := strings.CutSuffix(arg, "\"")
+	if prefixFound && suffixFound {
+		args = append(args, arg)
+	} else if !prefixFound && !suffixFound {
+		argsSplitted := strings.Split(arg, " ")
+		args = append(args, argsSplitted...)
+	} else {
+		err = errors.New("found only one quote can not parse connect argument")
+		return
+	}
+
+	for index := range args {
+		args[index] = strings.Replace(args[index], "?", ip, -1)
+	}
+	return args, nil
 }
 
 func (argument *Connect) Reset() {}

--- a/pkg/game/game.go
+++ b/pkg/game/game.go
@@ -3,7 +3,6 @@ package game
 import (
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/seternate/go-lanty/pkg/game/argument"
 )
@@ -102,17 +101,15 @@ func (executable *Executable) Args() (args []string, err error) {
 	return
 }
 
-func (executable *Executable) ParseConnectArg(ip string) ([]string, error) {
+func (executable *Executable) ParseConnectArg(ip string) (connectArg []string, err error) {
 	for _, arg := range executable.Arguments.Arguments {
 		if arg.GetType() == argument.TYPE_CONNECT {
-			connectArg, err := arg.(*argument.Connect).ParseWithIP(ip)
-			if err != nil {
-				return []string{}, err
-			}
-			return strings.Split(connectArg, " "), nil
+			connectArg, err = arg.(*argument.Connect).ParseWithIP(ip)
+			return
 		}
 	}
-	return []string{}, errors.New("executable can not connect")
+	err = errors.New("executable can not connect")
+	return
 }
 
 func (left *Executable) Equal(right Executable) bool {


### PR DESCRIPTION
An escaped connect argument is now passed as a single command-line argument. This fixes the direct connection problem with games like Teeworlds.

Before an escaped connect argument was passed along with the escaped quotes resulting in an odd behaviour joining a game.

Fixes https://github.com/seternate/go-lanty-client/issues/29