### PR TITLE
Fix empty command-line argument

### DIFF
--- a/pkg/game/argument/argument.go
+++ b/pkg/game/argument/argument.go
@@ -214,7 +214,9 @@ func (arguments *Arguments) Parse() (args []string, err error) {
 			tmpArguments = tmpArguments + tmpArg
 		}
 	}
-	args = strings.Split(tmpArguments, " ")
+	if len(tmpArguments) > 0 {
+		args = strings.Split(tmpArguments, " ")
+	}
 	return
 }
 


### PR DESCRIPTION
If no arguments where given an empty command-line argument was given to the game when being started. With this change no empty command-line argument will be given anymore.