### PR TITLE
Default server port changed to 8080

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -1,4 +1,4 @@
-serverport: 8090
+serverport: 8080
 game-config-directory: game-config
 game-file-directory: game-data
 game-icon-directory: game-icon


### PR DESCRIPTION
The default port the server is listing on incoming http requests changed from `8090` to `8080`.