### PR TITLE
Add file-upload API & file-message Chat API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 !pkg/
 !pkg/api/
 !pkg/chat/
+!pkg/file/
 !pkg/filesystem/
 !pkg/game/
 !pkg/game/argument/

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -51,18 +51,21 @@ func main() {
 		WithGamehandler().
 		WithUserhandler(errCtx, errgrp).
 		WithDownloadHandler().
-		WithChatHandler()
+		WithChatHandler().
+		WithFileHandler()
 	log.Trace().Msg("handler created")
 	gameRoutes := router.GameRoutes(handler)
 	userRoutes := router.UserRoutes(handler)
 	downloadRoutes := router.DownloadRoutes(handler)
 	chatRoutes := router.ChatRoutes(handler)
+	fileRoutes := router.FileRoutes(handler)
 	log.Trace().Msg("routes created")
 	router := router.NewRouter().
 		WithRoutes(gameRoutes).
 		WithRoutes(userRoutes).
 		WithRoutes(downloadRoutes).
-		WithRoutes(chatRoutes)
+		WithRoutes(chatRoutes).
+		WithRoutes(fileRoutes)
 	log.Trace().Msg("router created")
 
 	listener, err := net.Listen("tcp4", ":"+strconv.Itoa(settings.ServerPort))
@@ -116,4 +119,6 @@ func parseServerFlags(settings *setting.Settings) {
 	flag.IntVar(&settings.ServerGracefulShutdown, "graceful-shutdown", 10, "Timeout in seconds to wait for a graceful shutdown of the server")
 	flag.StringVar(&settings.GameConfigDirectory, "game-config-dir", settings.GameConfigDirectory, "Directory of the game configuration files")
 	flag.StringVar(&settings.GameFileDirectory, "game-file-dir", settings.GameFileDirectory, "Directory of the game files")
+	flag.StringVar(&settings.GameIconDirectory, "game-icon-dir", settings.GameIconDirectory, "Directory of the game icons")
+	flag.StringVar(&settings.FileUploadDirectory, "file-upload-dir", settings.FileUploadDirectory, "Directory of files uploaded by clients")
 }

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -18,6 +18,7 @@ type Client struct {
 	Game *GameService
 	User *UserService
 	Chat *ChatService
+	File *FileService
 }
 
 func NewClient(baseURL string, timeout time.Duration) (client *Client, err error) {
@@ -28,7 +29,8 @@ func NewClient(baseURL string, timeout time.Duration) (client *Client, err error
 	router := router.NewRouter().
 		WithRoutes(router.GameRoutes(nil)).
 		WithRoutes(router.UserRoutes(nil)).
-		WithRoutes(router.ChatRoutes(nil))
+		WithRoutes(router.ChatRoutes(nil)).
+		WithRoutes(router.FileRoutes(nil))
 
 	client = &Client{
 		httpclient: httpclient,
@@ -41,6 +43,7 @@ func NewClient(baseURL string, timeout time.Duration) (client *Client, err error
 		client:   client,
 		Messages: make(chan chat.Message, 100),
 	}
+	client.File = &FileService{client: client}
 
 	return
 }

--- a/pkg/api/fileservice.go
+++ b/pkg/api/fileservice.go
@@ -1,0 +1,86 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"mime"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/seternate/go-lanty/pkg/file"
+	"github.com/seternate/go-lanty/pkg/network"
+)
+
+type FileService struct {
+	client *Client
+}
+
+func (service *FileService) UploadFile(file string) (response file.FileUploadResponse, err error) {
+	f, err := os.Open(file)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	fstat, _ := f.Stat()
+	filesize := strconv.FormatInt(fstat.Size(), 10)
+
+	path, err := service.client.router.Get("PostFile").URLPath()
+	if err != nil {
+		return
+	}
+	request, err := service.client.newRESTRequest(http.MethodPost, service.client.buildURL(*path), nil, f)
+	if err != nil {
+		return
+	}
+	request.Header.Add("Content-Type", mime.TypeByExtension(filepath.Ext(file)))
+	request.ContentLength = fstat.Size()
+	request.Header.Add("Content-Length", filesize)
+	request.Header.Add("Content-Disposition", "attachment; filename="+filepath.Base(file))
+
+	r, err := service.client.doREST(request)
+	if err != nil {
+		return
+	}
+	defer r.Body.Close()
+
+	responsejson, err := io.ReadAll(r.Body)
+	if err != nil {
+		return
+	}
+
+	err = json.Unmarshal(responsejson, &response)
+
+	return
+}
+
+func (service *FileService) GetFile(ctx context.Context, url url.URL, directory string) (download *network.Download, err error) {
+	download, err = network.NewDownload(url)
+	if err != nil {
+		return
+	}
+
+	filepath := filepath.Join(directory, download.Filename())
+	if _, err := os.Stat(directory); os.IsNotExist(err) {
+		err = os.MkdirAll(directory, 0755)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	file, err := os.Create(filepath)
+	if err != nil {
+		return
+	}
+
+	download.StartDownload(ctx, file)
+	go func() {
+		<-download.Done
+		file.Close()
+	}()
+
+	return
+}

--- a/pkg/chat/filemessage.go
+++ b/pkg/chat/filemessage.go
@@ -1,0 +1,45 @@
+package chat
+
+import (
+	"path/filepath"
+	"time"
+
+	"github.com/seternate/go-lanty/pkg/file"
+	"github.com/seternate/go-lanty/pkg/user"
+)
+
+type FileMessage struct {
+	Type    Type                    `json:"type"`
+	User    user.User               `json:"user"`
+	Message file.FileUploadResponse `json:"message"`
+	Time    time.Time               `json:"time"`
+}
+
+func NewFileMessage(user user.User, fileuploadresponse file.FileUploadResponse) *FileMessage {
+	return &FileMessage{
+		Type:    TYPE_FILE,
+		User:    user,
+		Message: fileuploadresponse,
+		Time:    time.Now(),
+	}
+}
+
+func (message *FileMessage) GetType() Type {
+	return message.Type
+}
+
+func (message *FileMessage) GetUser() user.User {
+	return message.User
+}
+
+func (message *FileMessage) GetMessage() string {
+	return filepath.Base(message.Message.URL)
+}
+
+func (message *FileMessage) GetTime() time.Time {
+	return message.Time
+}
+
+func (message *FileMessage) SetTime(t time.Time) {
+	message.Time = t
+}

--- a/pkg/chat/message.go
+++ b/pkg/chat/message.go
@@ -44,6 +44,14 @@ func ReadMessage(r io.Reader) (Message, error) {
 			return nil, err
 		}
 		return textmessage, err
+	case TYPE_FILE:
+		filemessage := &FileMessage{}
+		err = json.Unmarshal(tmpMessageJson, filemessage)
+		if err != nil {
+			return nil, err
+		}
+		return filemessage, err
 	}
+
 	return nil, fmt.Errorf("undefined message type: %s", tmpMessage.Type.String())
 }

--- a/pkg/chat/type.go
+++ b/pkg/chat/type.go
@@ -10,6 +10,8 @@ func TypeFromString(s string) (Type, error) {
 	switch s {
 	case TYPE_TEXT.slug:
 		return TYPE_TEXT, nil
+	case TYPE_FILE.slug:
+		return TYPE_FILE, nil
 	}
 	return TYPE_UNDEFINED, errors.New("unknown type: " + s)
 }
@@ -17,6 +19,7 @@ func TypeFromString(s string) (Type, error) {
 var (
 	TYPE_UNDEFINED = Type{""}
 	TYPE_TEXT      = Type{"text"}
+	TYPE_FILE      = Type{"file"}
 )
 
 type Type struct {

--- a/pkg/file/file.go
+++ b/pkg/file/file.go
@@ -1,0 +1,5 @@
+package file
+
+type FileUploadResponse struct {
+	URL string `json:"url"`
+}

--- a/pkg/handler/file.go
+++ b/pkg/handler/file.go
@@ -1,0 +1,98 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/gorilla/mux"
+	"github.com/rs/zerolog/log"
+	"github.com/seternate/go-lanty/pkg/file"
+	"github.com/seternate/go-lanty/pkg/filesystem"
+	"github.com/seternate/go-lanty/pkg/network"
+)
+
+type Filehandler struct {
+	parent *Handler
+}
+
+func NewFileHandler(parent *Handler) (handler *Filehandler) {
+	handler = &Filehandler{
+		parent: parent,
+	}
+	return
+}
+
+func (handler *Filehandler) PostFile(w http.ResponseWriter, req *http.Request) {
+	download, err := network.NewDownloadFromRaw(req.Header, req.Body)
+	if err != nil {
+		log.Error().Err(err).Msg("error creating download for file upload")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	filepath := filepath.Join(handler.parent.Setting.FileUploadDirectory, download.Filename())
+	if _, err := os.Stat(handler.parent.Setting.FileUploadDirectory); os.IsNotExist(err) {
+		err = os.MkdirAll(handler.parent.Setting.FileUploadDirectory, 0755)
+		log.Debug().Str("directory", handler.parent.Setting.FileUploadDirectory).Msg("created missing file-upload directory")
+		if err != nil {
+			log.Error().Err(err).Msg("error creating file-upload directory")
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+	}
+
+	f, err := os.Create(filepath)
+	if err != nil {
+		log.Error().Err(err).Str("file", filepath).Msg("can not create file")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	defer f.Close()
+
+	download.Download(req.Context(), f)
+	if download.Err != nil {
+		log.Error().Err(download.Err).Str("file", filepath).Msg("failed to download file")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	fileurl := req.URL.JoinPath(download.Filename())
+	fileurl.Host = req.Host
+	if req.TLS != nil {
+		fileurl.Scheme = "https"
+	} else {
+		fileurl.Scheme = "http"
+	}
+	response := file.FileUploadResponse{
+		URL: fileurl.String(),
+	}
+
+	responseJson, err := json.Marshal(response)
+	if err != nil {
+		log.Error().Err(err).Interface("response", response).Msg("failed to encode response")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	w.Write(responseJson)
+}
+
+func (handler *Filehandler) GetFile(w http.ResponseWriter, req *http.Request) {
+	vars := mux.Vars(req)
+	filename := vars["filename"]
+
+	files, err := filesystem.SearchFileByNameLazy(filename, handler.parent.Setting.FileUploadDirectory)
+	if err != nil {
+		log.Error().Err(err).Str("filename", filename).Msg("failed to retrieve binary data")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	err = network.ServeFileData(files[0], w, req)
+	if err != nil {
+		log.Warn().Err(err).Str("file", files[0]).Msg("failed to serve file / provide meta-info")
+	}
+}

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -15,6 +15,7 @@ type Handler struct {
 	Userhandler     *Userhandler
 	Downloadhandler *Downloadhandler
 	Chathandler     *ChatHandler
+	Filehandler     *Filehandler
 }
 
 func NewHandler(settings *setting.Settings) *Handler {
@@ -45,5 +46,10 @@ func (handler *Handler) WithDownloadHandler() *Handler {
 
 func (handler *Handler) WithChatHandler() *Handler {
 	handler.Chathandler = NewChatHandler(handler)
+	return handler
+}
+
+func (handler *Handler) WithFileHandler() *Handler {
+	handler.Filehandler = NewFileHandler(handler)
 	return handler
 }

--- a/pkg/router/file.go
+++ b/pkg/router/file.go
@@ -1,0 +1,27 @@
+package router
+
+import (
+	"github.com/rs/zerolog/log"
+	"github.com/seternate/go-lanty/pkg/handler"
+)
+
+func FileRoutes(handler *handler.Handler) (routes Routes) {
+	routes = Routes{
+		"PostFile":    Route{"PostFile", "POST", "/files", nil},
+		"GetFileHEAD": Route{"GetFile", "HEAD", "/files/{filename}", nil},
+		"GetFileGET":  Route{"GetFile", "GET", "/files/{filename}", nil},
+	}
+
+	if handler == nil || handler.Gamehandler == nil {
+		log.Trace().Msg("no HandlerFunc added to routes for files")
+		return
+	}
+
+	routes.UpdateHandlerFunc("PostFile", handler.Filehandler.PostFile)
+	routes.UpdateHandlerFunc("GetFileHEAD", handler.Filehandler.GetFile)
+	routes.UpdateHandlerFunc("GetFileGET", handler.Filehandler.GetFile)
+
+	log.Trace().Msg("HandlerFunc added to routes for files")
+
+	return
+}

--- a/pkg/setting/settings.go
+++ b/pkg/setting/settings.go
@@ -15,6 +15,7 @@ type Settings struct {
 	GameConfigDirectory    string `yaml:"game-config-directory"`
 	GameFileDirectory      string `yaml:"game-file-directory"`
 	GameIconDirectory      string `yaml:"game-icon-directory"`
+	FileUploadDirectory    string `yaml:"file-upload-directory"`
 }
 
 func LoadSettings() (settings Settings, err error) {

--- a/settings.yaml
+++ b/settings.yaml
@@ -2,3 +2,4 @@ serverport: 8080
 game-config-directory: game-config
 game-file-directory: game-data
 game-icon-directory: game-icon
+file-upload-directory: file-upload


### PR DESCRIPTION
The chat API now supports filemessages. Therefore a file upload API was introduced, so that files can be uploaded to the server and the uploaded files can be downloaded with the help of fileupload respnses, which contain the download URL. With this functionallity filemessages can be send in the chat, so that files can be shared among users.

Addresses: https://github.com/seternate/go-lanty/pull/14