### PR TITLE
Configure clients `serverurl` setting

### DIFF
--- a/pkg/setting/settings.go
+++ b/pkg/setting/settings.go
@@ -10,12 +10,13 @@ const (
 )
 
 type Settings struct {
-	ServerPort             int    `yaml:"serverport"`
-	ServerGracefulShutdown int    `yaml:"-"`
-	GameConfigDirectory    string `yaml:"game-config-directory"`
-	GameFileDirectory      string `yaml:"game-file-directory"`
-	GameIconDirectory      string `yaml:"game-icon-directory"`
-	FileUploadDirectory    string `yaml:"file-upload-directory"`
+	Host                string `yaml:"host"`
+	Port                int    `yaml:"port"`
+	GracefulShutdown    int    `yaml:"-"`
+	GameConfigDirectory string `yaml:"game-config-directory"`
+	GameFileDirectory   string `yaml:"game-file-directory"`
+	GameIconDirectory   string `yaml:"game-icon-directory"`
+	FileUploadDirectory string `yaml:"file-upload-directory"`
 }
 
 func LoadSettings() (settings Settings, err error) {

--- a/settings.yaml
+++ b/settings.yaml
@@ -1,4 +1,5 @@
-serverport: 8080
+#host: lanty
+port: 8080
 game-config-directory: game-config
 game-file-directory: game-data
 game-icon-directory: game-icon


### PR DESCRIPTION
The client applications `serverurl` setting is configured on startup and saved into its YAML settings file. Therefore a user does not need to configure the serverurl after downloading the client from the server application.

Fixes https://github.com/seternate/go-lanty/issues/1